### PR TITLE
Add github cd for backend with docker build and push

### DIFF
--- a/.github/workflows/example-backend-cd.yaml
+++ b/.github/workflows/example-backend-cd.yaml
@@ -1,0 +1,45 @@
+name: Example GitHub Actions CD for example backend
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - closed
+
+defaults:
+  run:
+    shell: bash
+    working-directory: ./example-backend
+
+jobs:
+  Push:
+    if: github.event.pull_request.merged == true
+    name: Push Production Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    environment: CD
+    permissions:
+      packages: write
+      contents: read
+      attestations: write
+      id-token: write
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: ./example-backend
+          file: ./example-backend/Dockerfile.production
+          push: true
+          tags: alexanderpaulsell/example-backend:latest

--- a/.github/workflows/example-frontend-ci.yaml
+++ b/.github/workflows/example-frontend-ci.yaml
@@ -1,5 +1,4 @@
 name: Example GitHub Actions CI for example frontend
-run-name:
 on: [pull_request]
 
 defaults:


### PR DESCRIPTION
Assuming our deployment uses kubernetes, the only cd we need is to publish the image to docker hub.