### PR TITLE
Add frontend cd with build and push docker image to docker hub

### DIFF
--- a/.github/workflows/example-backend-ci.yaml
+++ b/.github/workflows/example-backend-ci.yaml
@@ -1,4 +1,4 @@
-name: Example GitHub Actions CI for example backend
+name: Example GitHub Actions CI for backend
 run-name:
 on: [pull_request]
 

--- a/.github/workflows/example-frontend-cd.yaml
+++ b/.github/workflows/example-frontend-cd.yaml
@@ -1,0 +1,45 @@
+name: Example GitHub Actions CD for frontend
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - closed
+
+defaults:
+  run:
+    shell: bash
+    working-directory: ./example-frontend
+
+jobs:
+  Push:
+    if: github.event.pull_request.merged == true
+    name: Push Production Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    environment: CD
+    permissions:
+      packages: write
+      contents: read
+      attestations: write
+      id-token: write
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: ./example-frontend
+          file: ./example-frontend/Dockerfile.production
+          push: true
+          tags: alexanderpaulsell/example-frontend:latest


### PR DESCRIPTION
This workflow follows the backend cd for the same reason: This will eventually be deployed via kubernetes which can just grab the image from docker hub.